### PR TITLE
TensorRT: 転送・推論を非同期に行う

### DIFF
--- a/usi/nn_tensorrt.cpp
+++ b/usi/nn_tensorrt.cpp
@@ -31,6 +31,8 @@ constexpr long long int operator"" _MiB(long long unsigned int val)
 
 NNTensorRT::NNTensorRT(const char* filename, const int gpu_id, const int max_batch_size) : gpu_id(gpu_id), max_batch_size(max_batch_size)
 {
+	// Create stream
+	checkCudaErrors(cudaStreamCreate(&stream));
 	// Create host and device buffers
 	checkCudaErrors(cudaMalloc((void**)&x1_dev, sizeof(features1_t) * max_batch_size));
 	checkCudaErrors(cudaMalloc((void**)&x2_dev, sizeof(features2_t) * max_batch_size));
@@ -44,6 +46,7 @@ NNTensorRT::NNTensorRT(const char* filename, const int gpu_id, const int max_bat
 
 NNTensorRT::~NNTensorRT()
 {
+	checkCudaErrors(cudaStreamDestroy(stream));
 	checkCudaErrors(cudaFree(x1_dev));
 	checkCudaErrors(cudaFree(x2_dev));
 	checkCudaErrors(cudaFree(y1_dev));
@@ -192,10 +195,20 @@ void NNTensorRT::forward(const int batch_size, features1_t* x1, features2_t* x2,
 	context->setBindingDimensions(0, inputDims1);
 	context->setBindingDimensions(1, inputDims2);
 
+#if 1
+	checkCudaErrors(cudaMemcpyAsync(x1_dev, x1, sizeof(features1_t) * batch_size, cudaMemcpyHostToDevice, stream));
+	checkCudaErrors(cudaMemcpyAsync(x2_dev, x2, sizeof(features2_t) * batch_size, cudaMemcpyHostToDevice, stream));
+	const bool status = context->enqueue(batch_size, inputBindings.data(), stream, nullptr);
+	assert(status);
+	checkCudaErrors(cudaMemcpyAsync(y1, y1_dev, sizeof(DType) * MAX_MOVE_LABEL_NUM * (size_t)SquareNum * batch_size , cudaMemcpyDeviceToHost, stream));
+	checkCudaErrors(cudaMemcpyAsync(y2, y2_dev, sizeof(DType) * batch_size, cudaMemcpyDeviceToHost, stream));
+	checkCudaErrors(cudaStreamSynchronize(stream));
+#else
 	checkCudaErrors(cudaMemcpy(x1_dev, x1, sizeof(features1_t) * batch_size, cudaMemcpyHostToDevice));
 	checkCudaErrors(cudaMemcpy(x2_dev, x2, sizeof(features2_t) * batch_size, cudaMemcpyHostToDevice));
 	const bool status = context->executeV2(inputBindings.data());
 	assert(status);
 	checkCudaErrors(cudaMemcpy(y1, y1_dev, MAX_MOVE_LABEL_NUM * (size_t)SquareNum * batch_size * sizeof(DType), cudaMemcpyDeviceToHost));
 	checkCudaErrors(cudaMemcpy(y2, y2_dev, batch_size * sizeof(DType), cudaMemcpyDeviceToHost));
+#endif
 }

--- a/usi/nn_tensorrt.h
+++ b/usi/nn_tensorrt.h
@@ -38,6 +38,7 @@ private:
 	DType* y2_dev;
 	std::vector<void*> inputBindings;
 	InferUniquePtr<nvinfer1::IExecutionContext> context;
+	cudaStream_t stream;
 	nvinfer1::Dims inputDims1;
 	nvinfer1::Dims inputDims2;
 


### PR DESCRIPTION
`cudaStream_t stream` はこのPRではGPUごとに持っていますが、推論自体を並列に行いたい時は `context`, `stream`, `inputDims1`, `inputDims2`, `x1_dev`, `x2_dev`, `y1_dev`, `y2_dev` などは探索スレッドごとに持つように変更した方が良いかもしれません。（推測であり未確認）

参考:
ふかうら王 アピール文章
https://drive.google.com/open?id=1aO0gLSYvhph1uL_gaaohLYWTMpe1BdA8