### PR TITLE
make_bookターゲットでcuda_objectsを含める

### DIFF
--- a/usi/Makefile
+++ b/usi/Makefile
@@ -34,7 +34,7 @@ all: $(target)
 clean:
 	rm -f $(objects) $(cppshogi_objects) $(target) $(cuda_objects)
 
-$(target_make_book): $(objects) $(cppshogi_objects)
+$(target_make_book): $(objects) $(cppshogi_objects) $(cuda_objects)
 	@[ -d bin ] || mkdir -p bin
 	$(CC) -o $@ $^ $(LIB) $(LDFLAGS) $(CFLAGS)
 


### PR DESCRIPTION
Makefile での make_book ターゲットのビルドで発生する以下のエラーに対する処置です。
```
/usr/bin/ld: obj/nn_tensorrt.o: in function `NNTensorRT::forward(int, char (*) [628], char (*) [8], float*, float*)':
nn_tensorrt.cpp:(.text+0x17f1): undefined reference to `unpack_features1(int, char (*) [628], float (*) [2][31][81], CUstream_st*)'
/usr/bin/ld: nn_tensorrt.cpp:(.text+0x1806): undefined reference to `unpack_features2(int, char (*) [8], float (*) [57][81], CUstream_st*)'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```