### PR TITLE
AobaZeroの新しい棋譜コメントに対応

### DIFF
--- a/dlshogi/utils/aoba_to_hcpe3.py
+++ b/dlshogi/utils/aoba_to_hcpe3.py
@@ -102,7 +102,14 @@ for filepath in csa_file_list:
                 break
             comments = comment.split(',')
             if comments[0].startswith('v='):
-                candidates = comments[1:]
+
+                # AobaZeroの新しい棋譜には、v=xxx, のあとに r=xxx が書いてある。
+                # これは無いものとして扱う。
+                if comments[1].startswith('r='):
+                    candidates = comments[2:]
+                else:
+                    candidates = comments[1:]
+
                 v = float(comments[0].split('=')[1])
                 if v == 1.0:
                     move_info['eval'] = 30000
@@ -122,6 +129,11 @@ for filepath in csa_file_list:
                 m = board.move_from_csa(csa)
                 assert(board.is_legal(m))
                 move_visits[j]['move16'] = move16(m)
+
+                # AobaZeroの新しい棋譜には、訪問回数の末尾にalphabetがあるのでこれは除去する。
+                if visit_num[-1].isalpha():
+                    visit_num = visit_num[:-1]
+
                 move_visits[j]['visitNum'] = visit_num
             move_visits_list.append(move_visits)
             p += 1


### PR DESCRIPTION
AobaZeroの棋譜コメントのフォーマットが変更されたため(2023年12月ごろ？)、hcpe3形式へ変換するスクリプト（aoba_to_hcpe3.py）の修正が必要となりました。

この修正により、以前の棋譜も新しい棋譜も正しく変換することができるようになります。